### PR TITLE
관리자 주문 목록 페이지네이션 및 성능 개선

### DIFF
--- a/backend/src/main/java/com/example/aromadesk/admin/controller/AdminOrderController.java
+++ b/backend/src/main/java/com/example/aromadesk/admin/controller/AdminOrderController.java
@@ -6,6 +6,9 @@ import com.example.aromadesk.order.entity.Order;
 import com.example.aromadesk.order.repository.OrderRepository;
 import com.example.aromadesk.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,11 +25,12 @@ public class AdminOrderController {
     private final OrderService orderService;
 
     @GetMapping
-    public ResponseEntity<List<OrderResponseDto>> getAllOrdersForAdmin() {
-        List<Order> allOrders = orderRepository.findAll(); // 전체 주문 조회
-        List<OrderResponseDto> result = allOrders.stream()
-                .map(OrderResponseDto::from)
-                .collect(Collectors.toList());
+    public ResponseEntity<Page<OrderResponseDto>> getAllOrdersForAdmin(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+
+        PageRequest pageRequest = PageRequest.of(page, size,  Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<Order> orderPage = orderRepository.findAll(pageRequest);   //페이지네이션
+        Page<OrderResponseDto> result = orderPage.map(OrderResponseDto::from);
         return ResponseEntity.ok(result);
     }
 

--- a/frontend/src/PagesAdmin/AdminOrderPage.js
+++ b/frontend/src/PagesAdmin/AdminOrderPage.js
@@ -14,6 +14,11 @@ import "../css/AdminOrderPage.css";
 function AdminOrderPage() {
     const [orders, setOrders] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [page, setPage] = useState(1);
+    const [size, setSize] = useState(10);
+    const [totalPages, setTotalPages] = useState(1);
+    const [totalElements, setTotalElements] = useState(0);
+
     const navigate = useNavigate();
 
     // 주문 상태 한글 매핑
@@ -31,13 +36,33 @@ function AdminOrderPage() {
         CANCELLED: "배송 취소",
     };
 
+    // 주문 목록 조회
+    const fetchOrders = async (pageParam = page) => {
+        try {
+            setIsLoading(true);
+            const res = await apiClient.get("/api/admin/orders", {
+                params: {
+                    page: pageParam - 1, // 백엔드는 0부터 시작
+                    size,
+                },
+            });
+            setOrders(res.data.content || []);
+            setTotalPages(res.data.totalPages || 1);
+            setTotalElements(res.data.totalElements || 0);
+        } catch (error) {
+            console.error("주문 목록 조회 실패", error);
+            setOrders([]);
+            setTotalPages(1);
+            setTotalElements(0);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
     useEffect(() => {
-        apiClient.get("/api/admin/orders")
-            .then(res => setOrders(res.data))
-            .catch(() => setOrders([]))
-            .finally(() => setIsLoading(false));
-    }, []);
-  
+        fetchOrders();
+    }, [page, size]);
+
     return (
         <AdminLayout>
             <div className="admin-order-page">
@@ -45,42 +70,60 @@ function AdminOrderPage() {
                 <h2 style={{ fontSize: '16px', color: '#888', marginBottom: '24px' }}>
                     주문 내역의 상태를 확인하는 페이지 입니다
                 </h2>
+
                 {isLoading ? (
                     <div className="admin-order-loading">불러오는 중...</div>
                 ) : orders.length === 0 ? (
                     <div className="admin-order-empty">주문이 없습니다.</div>
                 ) : (
-                    <table className="admin-order-table">
-                        <thead>
-                            <tr>
-                                <th>주문번호</th>
-                                <th>회원</th>
-                                <th>주문 상태</th>
-                                <th>배송 상태</th>
-                                <th>총금액</th>
-                                <th>날짜</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {orders.map(order => (
-                                <tr key={order.orderId}>
-                                    <td>{order.orderId}</td>
-                                    <td>
-                                        <span
-                                            onClick={() => navigate(`/admin/orders/${order.orderId}`)}
-                                            style={{ cursor: "pointer", textDecoration: "underline", color: "#1b5e20" }}
-                                        >
-                                            {order.memberName}
-                                        </span>
-                                    </td>
-                                    <td>{orderStatusMap[order.orderStatus] || order.orderStatus}</td>
-                                    <td>{deliveryStatusMap[order.deliveryStatus] || order.deliveryStatus}</td>
-                                    <td>{order.totalPrice?.toLocaleString()}원</td>
-                                    <td>{order.orderDate?.slice(0, 10)}</td>
+                    <>
+                        <div className="pagination-bar">
+                            <span>총 {totalElements}건 | </span>
+                            <button onClick={() => setPage(page - 1)} disabled={page <= 1}>이전</button>
+                            <span style={{ margin: "0 8px" }}>{page} / {totalPages}</span>
+                            <button onClick={() => setPage(page + 1)} disabled={page >= totalPages}>다음</button>
+                            <select
+                                value={size}
+                                onChange={(e) => setSize(Number(e.target.value))}
+                            >
+                                <option value={10}>10개씩</option>
+                                <option value={20}>20개씩</option>
+                                <option value={50}>50개씩</option>
+                            </select>
+                        </div>
+
+                        <table className="admin-order-table">
+                            <thead>
+                                <tr>
+                                    <th>주문번호</th>
+                                    <th>회원</th>
+                                    <th>주문 상태</th>
+                                    <th>배송 상태</th>
+                                    <th>총금액</th>
+                                    <th>날짜</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                                {orders.map(order => (
+                                    <tr key={order.orderId}>
+                                        <td>{order.orderId}</td>
+                                        <td>
+                                            <span
+                                                onClick={() => navigate(`/admin/orders/${order.orderId}`)}
+                                                style={{ cursor: "pointer", textDecoration: "underline", color: "#1b5e20" }}
+                                            >
+                                                {order.memberName}
+                                            </span>
+                                        </td>
+                                        <td>{orderStatusMap[order.orderStatus] || order.orderStatus}</td>
+                                        <td>{deliveryStatusMap[order.deliveryStatus] || order.deliveryStatus}</td>
+                                        <td>{order.totalPrice?.toLocaleString()}원</td>
+                                        <td>{order.orderDate?.slice(0, 10)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </>
                 )}
             </div>
         </AdminLayout>


### PR DESCRIPTION
## 개요
- 관리자 주문 목록 페이지에서 전체 데이터 조회하던 방식을 페이지네이션으로 개선
- 데이터량이 증가해도 성능 저하 없이 안정적으로 조회 가능하도록 수정

## 주요 변경 사항
- OrderController: findAll() → findAll(Pageable) 로 변경
- AdminOrderPage.js:
  - 주문 목록 조회 시 page, size 파라미터 추가
  - 페이지네이션 UI 추가 (이전 / 다음 버튼, 페이지당 개수 선택)
- 주문 상태, 배송 상태 한글 변환 로직 유지
- 기본 페이지 size = 10 으로 설정, totalElements 표시 추가

## 성능 개선 효과
- 개선 전: 전체 데이터 반환 (데이터량 증가 시 조회 시간 선형 증가)
- 개선 후: 10개 단위 조회로 고정, 데이터량이 많아져도 일정한 속도 유지
