### PR TITLE
관리자 주문 목록 조회 n+1 문제 해결 및 성능 개선

### DIFF
--- a/backend/src/main/java/com/example/aromadesk/admin/controller/AdminOrderController.java
+++ b/backend/src/main/java/com/example/aromadesk/admin/controller/AdminOrderController.java
@@ -25,14 +25,17 @@ public class AdminOrderController {
     private final OrderService orderService;
 
     @GetMapping
-    public ResponseEntity<Page<OrderResponseDto>> getAllOrdersForAdmin(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+    public ResponseEntity<Page<OrderResponseDto>> getAllOrdersForAdmin(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
 
-        PageRequest pageRequest = PageRequest.of(page, size,  Sort.by(Sort.Direction.DESC, "createdAt"));
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        Page<Order> orderPage = orderRepository.findAll(pageRequest);   //페이지네이션
-        Page<OrderResponseDto> result = orderPage.map(OrderResponseDto::from);
+        Page<OrderResponseDto> result = orderService.getAllOrdersForAdmin(pageRequest);
+
         return ResponseEntity.ok(result);
     }
+
 
     /**
      * 주문 상세 조회 (배송 정보 포함)

--- a/backend/src/main/java/com/example/aromadesk/order/dto/OrderProductNameDto.java
+++ b/backend/src/main/java/com/example/aromadesk/order/dto/OrderProductNameDto.java
@@ -1,0 +1,19 @@
+package com.example.aromadesk.order.dto;
+
+public class OrderProductNameDto {
+    private Long orderId;
+    private String productName;
+
+    public OrderProductNameDto(Long orderId, String productName) {
+        this.orderId = orderId;
+        this.productName = productName;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+}

--- a/backend/src/main/java/com/example/aromadesk/order/dto/OrderResponseDto.java
+++ b/backend/src/main/java/com/example/aromadesk/order/dto/OrderResponseDto.java
@@ -23,7 +23,15 @@ public class OrderResponseDto {
     private List<String> productNames;
     private String memberName;
 
+    // 기본 from 메서드 (상품명 직접 추출)
     public static OrderResponseDto from(Order order) {
+        return from(order, order.getOrderItems().stream()
+                .map(item -> item.getProduct().getName())
+                .collect(Collectors.toList()));
+    }
+
+    // productNames 파라미터로 받는 버전 (N+1 문제 해결용)
+    public static OrderResponseDto from(Order order, List<String> productNames) {
         return OrderResponseDto.builder()
                 .orderId(order.getId())
                 .orderDate(order.getCreatedAt())
@@ -32,9 +40,7 @@ public class OrderResponseDto {
                 .totalPrice(order.getTotalPrice())
                 .deliveryId(order.getDelivery() != null ? order.getDelivery().getId() : null)
                 .deliveryStatus(order.getDelivery() != null ? order.getDelivery().getStatus().name() : null)
-                .productNames(order.getOrderItems().stream()
-                        .map(item -> item.getProduct().getName())
-                        .collect(Collectors.toList()))
+                .productNames(productNames)
                 .memberName(order.getMember().getName())
                 .build();
     }

--- a/backend/src/main/java/com/example/aromadesk/order/entity/OrderItem.java
+++ b/backend/src/main/java/com/example/aromadesk/order/entity/OrderItem.java
@@ -3,6 +3,9 @@ package com.example.aromadesk.order.entity;
 import com.example.aromadesk.product.entity.Product;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
+
+import java.util.List;
 
 @Builder
 @AllArgsConstructor

--- a/backend/src/main/java/com/example/aromadesk/order/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/example/aromadesk/order/repository/OrderItemRepository.java
@@ -1,0 +1,17 @@
+package com.example.aromadesk.order.repository;
+
+import com.example.aromadesk.order.dto.OrderProductNameDto;
+import com.example.aromadesk.order.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface OrderItemRepository  extends JpaRepository<OrderItem, Long> {
+    @Query("select new com.example.aromadesk.order.dto.OrderProductNameDto(oi.order.id, p.name) " +
+            "from OrderItem oi join oi.product p " +
+            "where oi.order.id in :orderIds")
+    List<OrderProductNameDto> findOrderProductNamesByOrderIds(@Param("orderIds") List<Long> orderIds);
+
+}

--- a/backend/src/main/java/com/example/aromadesk/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/example/aromadesk/order/repository/OrderRepository.java
@@ -1,6 +1,10 @@
 package com.example.aromadesk.order.repository;
 
+import com.example.aromadesk.order.dto.OrderItemDto;
+import com.example.aromadesk.order.dto.OrderProductNameDto;
 import com.example.aromadesk.order.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +27,17 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    @Query(
+            value = "select o from Order o join fetch o.delivery d join fetch o.member m",
+            countQuery = "select count(o) from Order o"
+    )
+    Page<Order> findAllWithDeliveryAndMember(Pageable pageable);
+
+    @Query("SELECT new com.example.aromadesk.order.dto.OrderProductNameDto(oi.order.id, p.name) " +
+            "FROM OrderItem oi " +
+            "JOIN oi.product p " +
+            "WHERE oi.order.id IN :orderIds")
+    List<OrderProductNameDto> findOrderProductNamesByOrderIds(@Param("orderIds") List<Long> orderIds);
+
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -63,3 +63,9 @@ spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kak
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# Hibernate ?? ?? ???
+spring.jpa.properties.hibernate.generate_statistics=true
+
+# ?? ?? ?? DEBUG? ??
+logging.level.org.hibernate.stat=debug


### PR DESCRIPTION
### 변경 내용
- 관리자 주문 목록 조회 시 발생하던 N+1 문제 해결
- fetch join 및 DTO projection 방식으로 상품명 조회 최적화
- OrderService, OrderRepository 수정
- 기존 findAllWithDeliveryAndMember 유지, 추가 쿼리로 상품명 일괄 조회
- 전체 쿼리 수 약 30 → 3으로 개선

### 영향 범위
- 관리자 주문 목록 조회 API (/api/admin/orders)
- 기존 사용자/관리자 주문 생성 및 상세 조회는 영향 없음

### 추가 확인 필요
- 성능 개선 확인 (쿼리 수 및 응답 속도 측정 완료)
- 기존 테스트 정상 작동 확인
